### PR TITLE
use `nproc` instead of hardcoded number of threads.

### DIFF
--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -98,10 +98,11 @@ Start a terminal, go to the root dir of the engine source code and type:
 
 ::
 
-    scons -j8 platform=linuxbsd
+    scons -j`nproc` platform=linuxbsd
 
 A good rule of thumb for the ``-j`` (*jobs*) flag, is to have at least as many
 threads compiling Godot as you have cores in your CPU, if not one or two more.
+```nproc``` can be used to automatically use the number of cores your system has.
 Feel free to add the ``-j`` option to any SCons command you see below.
 
 .. note::

--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -104,7 +104,7 @@ A good rule of thumb for the ``-j`` (*jobs*) flag, is to have at least as many
 threads compiling Godot as you have cores in your CPU, if not one or two more.
 Feel free to add the ``-j`` option to any SCons command you see below.
 
-You can automatically use all available cores with command substitution.
+You can automatically use all available CPU cores with command substitution.
 
 On Linux, you can use ``nproc``:
 
@@ -112,7 +112,7 @@ On Linux, you can use ``nproc``:
 
     scons -j$(nproc)
 
-On BSD, you can use ``sysctl -n hw.ncpu``:
+On \*BSD, you can use ``sysctl -n hw.ncpu``:
 
 ::
 

--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -98,7 +98,7 @@ Start a terminal, go to the root dir of the engine source code and type:
 
 ::
 
-    scons -j`nproc` platform=linuxbsd
+    scons -j$(nproc) platform=linuxbsd
 
 A good rule of thumb for the ``-j`` (*jobs*) flag, is to have at least as many
 threads compiling Godot as you have cores in your CPU, if not one or two more.

--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -98,12 +98,21 @@ Start a terminal, go to the root dir of the engine source code and type:
 
 ::
 
-    scons -j$(nproc) platform=linuxbsd
+    scons -j8 platform=linuxbsd
 
 A good rule of thumb for the ``-j`` (*jobs*) flag, is to have at least as many
 threads compiling Godot as you have cores in your CPU, if not one or two more.
-```nproc``` can be used to automatically use the number of cores your system has.
 Feel free to add the ``-j`` option to any SCons command you see below.
+
+You can automatically use all available cores with command subtitution.
+
+On Linux you can use ``nproc``:
+::
+    scons -j$(nproc)
+    
+On BSD you can use ``sysctl -n hw.ncpu``:
+::
+    scons -j$(sysctl -n hw.ncpu)  
 
 .. note::
 

--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -104,7 +104,7 @@ A good rule of thumb for the ``-j`` (*jobs*) flag, is to have at least as many
 threads compiling Godot as you have cores in your CPU, if not one or two more.
 Feel free to add the ``-j`` option to any SCons command you see below.
 
-You can automatically use all available cores with command subtitution.
+You can automatically use all available cores with command substitution.
 
 On Linux you can use ``nproc``:
 ::

--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -45,7 +45,7 @@ Distro-specific one-liners
 | **Debian** /     | ::                                                                                                        |
 | **Ubuntu**       |                                                                                                           |
 |                  |     sudo apt-get install build-essential scons pkg-config libx11-dev libxcursor-dev libxinerama-dev \     |
-|                  |         libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm   |
+|                  |         libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm   |subtitution
 +------------------+-----------------------------------------------------------------------------------------------------------+
 | **Fedora**       | ::                                                                                                        |
 |                  |                                                                                                           |
@@ -109,7 +109,7 @@ You can automatically use all available cores with command substitution.
 On Linux you can use ``nproc``:
 ::
     scons -j$(nproc)
-    
+
 On BSD you can use ``sysctl -n hw.ncpu``:
 ::
     scons -j$(sysctl -n hw.ncpu)  

--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -109,11 +109,13 @@ You can automatically use all available cores with command substitution.
 On Linux you can use ``nproc``:
 
 ::
+
     scons -j$(nproc)
 
 On BSD you can use ``sysctl -n hw.ncpu``:
 
 ::
+
     scons -j$(sysctl -n hw.ncpu)  
 
 .. note::

--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -106,13 +106,13 @@ Feel free to add the ``-j`` option to any SCons command you see below.
 
 You can automatically use all available cores with command substitution.
 
-On Linux you can use ``nproc``:
+On Linux, you can use ``nproc``:
 
 ::
 
     scons -j$(nproc)
 
-On BSD you can use ``sysctl -n hw.ncpu``:
+On BSD, you can use ``sysctl -n hw.ncpu``:
 
 ::
 

--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -45,7 +45,7 @@ Distro-specific one-liners
 | **Debian** /     | ::                                                                                                        |
 | **Ubuntu**       |                                                                                                           |
 |                  |     sudo apt-get install build-essential scons pkg-config libx11-dev libxcursor-dev libxinerama-dev \     |
-|                  |         libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm   |subtitution
+|                  |         libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm   |
 +------------------+-----------------------------------------------------------------------------------------------------------+
 | **Fedora**       | ::                                                                                                        |
 |                  |                                                                                                           |

--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -107,10 +107,12 @@ Feel free to add the ``-j`` option to any SCons command you see below.
 You can automatically use all available cores with command substitution.
 
 On Linux you can use ``nproc``:
+
 ::
     scons -j$(nproc)
 
 On BSD you can use ``sysctl -n hw.ncpu``:
+
 ::
     scons -j$(sysctl -n hw.ncpu)  
 


### PR DESCRIPTION
on linux nproc command prints the number of virtual cores available, and putting it inside grave accents will evaluate the command and replace it with its output.